### PR TITLE
fix: retry adding button if the dom wasn't ready

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@
 // @author       Anthony Fu
 // @license      MIT
 // @match        https://github.com/**
-// @match        https://github.com/**#**
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=pr.new
 // @grant        none
 // ==/UserScript==
@@ -67,6 +66,7 @@
   }
 
   run()
+  setTimeout(run, 500) // deduped, no harm in making sure the dom is ready
 
   // listen to github page loaded event
   document.addEventListener('pjax:end', () => run())

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@
 // @author       Anthony Fu
 // @license      MIT
 // @match        https://github.com/**
+// @match        https://github.com/**#**
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=pr.new
 // @grant        none
 // ==/UserScript==


### PR DESCRIPTION
### Description

Retry to make sure the dom is ready.

Edit: It wasn't the matcher

Interesting that the matcher doesn't work for links to comments: https://github.com/vitejs/vite/pull/12851#discussion_r1166847717

Added another match rule and it works for me. Maybe there is a more general matcher?